### PR TITLE
Improvements, extensions and some fixes

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -43,15 +43,15 @@ markdown.toHtml('# Hello World', function (html) {
 A common use case might be opening a markdown file and then parsing it into HTML.
 
 ```javascript
-var fs = require('fs');                       
-var sys = require('sys');                     
-var markdown = require('robotskirt');         
-                                              
+var fs = require('fs');
+var sys = require('sys');
+var markdown = require('robotskirt');
+
 fs.readFile('README.mkd', function (err, data) {
   markdown.toHtml(data.toString(), function (html) {
-    sys.puts(html);            
+    sys.puts(html);
   });
-});                                           
+});
 ```
 
 If you would like to parse your markdown synchronously you can use the `toHtmlSync` function.
@@ -62,9 +62,10 @@ var html = markdown.toHtmlSync("*sync!*");
 
 ## Contributors
 
-* [Phinze](https://github.com/phinze) 
-* [Tim Branyen](https://github.com/tbranyen) 
+* [Phinze](https://github.com/phinze)
+* [Tim Branyen](https://github.com/tbranyen)
 * [Ryan Graham](https://github.com/rmg)
+* [Xavier Mendez](https://github.com/jmendeth)
 
 ## License
 

--- a/README.mkd
+++ b/README.mkd
@@ -1,9 +1,14 @@
 # Robotskirt
 
-Robotskirt is a simple node binding for the [sundown](https://github.com/tanoku/sundown) markdown parser. It was inspired by the redcarpet gem [released by github](https://github.com/blog/832-rolling-out-the-redcarpet). Eventually robotskirt should mirror the feature set of redcarpet, currently it is lacking flags.
+Robotskirt is a simple node binding for the [sundown](https://github.com/tanoku/sundown)
+markdown parser. It was inspired by the Redcarpet gem
+[released by github](https://github.com/blog/832-rolling-out-the-redcarpet).  
+Eventually Robotskirt should mirror the feature set of redcarpet,
+currently it doesn't support custom renderers.
 
 ## Performance
-Benchmarked against other popular node markdown libraries by running the entire official markdown test suit 1000 times.
+Benchmarked against other popular node markdown libraries by running
+the entire official markdown test suit 1000 times.
 
 ```bash
 $ node index.js --bench
@@ -16,13 +21,15 @@ showdown (new converter) completed in 15799ms.
 
 ## Install
 
-The best way to install robotskirt is by using [npm](https://github.com/isaacs/npm). If you want to install it globally, remember to include the -g flag.
+The best way to install robotskirt is by using [npm](https://github.com/isaacs/npm).
+If you want to install it globally, remember to include the -g flag.
 
 ```bash
 npm install robotskirt
 ```
 
-If you would like to compile it, you can use node's WAF wapper. Read more about how node C/C++ addons work in the [node docs](http://nodejs.org/docs/v0.4.7/api/addons.html).
+If you would like to compile it, you should use node's WAF wapper.
+Read more about how node C/C++ addons work in the [node docs](http://nodejs.org/docs/v0.4.7/api/addons.html).
 
 ```bash
 node-waf configure build
@@ -30,34 +37,56 @@ node-waf configure build
 
 ## Usage
 
-Currently robotskirt has one main function, `toHtml`, that will take a string of markdown and a callback that will be passed the parsed HTML. 
+First of all, you need to construct a `new HtmlRenderer`.  
+Then, call the `markdown` function passing your renderer as a first argument,
+the markdown code to parse, and a callback to handle the result:
 
 ```javascript
-var markdown = require('robotskirt');
-markdown.toHtml('# Hello World', function (html) {
+var rs = require('robotskirt');
+  , sys = require('sys');
+
+var renderer = new rs.HtmlRenderer();
+rs.markdown(renderer, '# Hello World', function (html) {
   sys.puts(html);
 });
 // '<h1>Hello World</h1>\n'
 ```
 
-A common use case might be opening a markdown file and then parsing it into HTML.
+For example, to read and parse a Markdown file:
 
 ```javascript
-var fs = require('fs');
-var sys = require('sys');
-var markdown = require('robotskirt');
+var rs = require('robotskirt')
+  , fs = require('fs')
+  , sys = require('sys');
 
+var renderer = new rs.HtmlRenderer();
 fs.readFile('README.mkd', function (err, data) {
-  markdown.toHtml(data.toString(), function (html) {
+  rs.markdown(renderer, data, function (html) {
     sys.puts(html);
   });
 });
 ```
 
-If you would like to parse your markdown synchronously you can use the `toHtmlSync` function.
+**Note:** keep in mind that the result is passed as a `Buffer` rather than a `String`,
+so you may convert it to text using `toString()`. See the last example.
+
+### Markdown extension flags
+
+You can pass some flags to Sundown by passing them as the last argument:
 
 ```javascript
-var html = markdown.toHtmlSync("*sync!*");
+var flags = rs.EXT_FENCED_CODE & rs.EXT_AUTOLINK;
+rs.markdown(renderer, 'Wow, this becomes http://autolink.ed', function (html) {
+  sys.puts(html);
+}, flags);
+```
+
+### Synchronous...
+
+If you would like to parse your markdown synchronously you can use the `markdownSync` function:
+
+```javascript
+var html = rs.markdownSync(new rs.HtmlRenderer(), "*sync!*");
 ```
 
 ## Contributors

--- a/README.mkd
+++ b/README.mkd
@@ -68,9 +68,6 @@ fs.readFile('README.mkd', function (err, data) {
 });
 ```
 
-**Note:** keep in mind that the result is passed as a `Buffer` rather than a `String`,
-so you may convert it to text using `toString()`. See the last example.
-
 ### Markdown extension flags
 
 You can pass some flags to Sundown by passing them as an (optional) last argument:
@@ -87,8 +84,11 @@ rs.markdown(renderer, 'Wow, this becomes http://autolink.ed !', function (html) 
 If you would like to parse your markdown synchronously you can use the `markdownSync` function:
 
 ```javascript
-var html = rs.markdownSync(new rs.HtmlRenderer(), "*sync!*");
+var html = rs.markdownSync(new rs.HtmlRenderer(), "*sync!*").toString();
 ```
+
+**Note:** keep in mind that the result is passed as a `Buffer` rather than a `String`,
+so you may convert it to text using `toString()`, as in this example.
 
 ## Contributors
 

--- a/README.mkd
+++ b/README.mkd
@@ -12,11 +12,12 @@ the entire official markdown test suit 1000 times.
 
 ```bash
 $ node index.js --bench
-robotskirt completed in 1849ms.
-marked completed in 5158ms.
-discount completed in 7661ms.
-showdown (reuse converter) completed in 13124ms.
-showdown (new converter) completed in 15799ms.
+robotskirt (reuse renderer) completed in 1794ms.
+robotskirt (new renderer) completed in 1848ms.
+marked completed in 5517ms.
+discount completed in 5866ms.
+showdown (reuse converter) completed in 13789ms.
+showdown (new converter) completed in 17161ms.
 ```
 
 ## Install

--- a/README.mkd
+++ b/README.mkd
@@ -37,8 +37,8 @@ node-waf configure build
 
 ## Usage
 
-First of all, you need to construct a `new HtmlRenderer`.  
-Then, call the `markdown` function passing your renderer as a first argument,
+First of all, you need to construct a `new HtmlRenderer()`.  
+Then, call the `markdown` function passing as arguments your renderer,  
 the markdown code to parse, and a callback to handle the result:
 
 ```javascript
@@ -72,16 +72,16 @@ so you may convert it to text using `toString()`. See the last example.
 
 ### Markdown extension flags
 
-You can pass some flags to Sundown by passing them as the last argument:
+You can pass some flags to Sundown by passing them as an (optional) last argument:
 
 ```javascript
 var flags = rs.EXT_FENCED_CODE & rs.EXT_AUTOLINK;
-rs.markdown(renderer, 'Wow, this becomes http://autolink.ed', function (html) {
+rs.markdown(renderer, 'Wow, this becomes http://autolink.ed !', function (html) {
   sys.puts(html);
 }, flags);
 ```
 
-### Synchronous...
+### Being synchronous...
 
 If you would like to parse your markdown synchronously you can use the `markdownSync` function:
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -132,7 +132,22 @@ main.bench = function(name, func) {
 };
 
 var bench = function() {
-  main.bench('robotskirt', require('../build/Release/robotskirt').toHtmlSync);
+  var robotskirt = (function() {
+    var rs = require('../build/Release/robotskirt');
+    var rend = new rs.HtmlRenderer();
+    return function(text) {
+      return rs.markdownSync(rend, text);
+    };
+  })();
+  main.bench('robotskirt (reuse renderer)', robotskirt);
+
+  var robotskirt_slow = (function() {
+    var rs = require('../build/Release/robotskirt');
+    return function(text) {
+      return rs.markdownSync(new rs.HtmlRenderer(), text);
+    };
+  })();
+  main.bench('robotskirt (new renderer)', robotskirt_slow);
 
   var marked = require('marked');
   main.bench('marked', marked);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "description": "A node wrapper for the awesome C markdown parsing library, sundown."
 , "tags": ["sundown", "upskirt", "robot", "markdown", "mkd"]
 , "author" : "Ben Mills <ben@bmdev.org>"
-, "version": "0.2.5"
+, "version": "1.2.2"
 , "lib": "./build/Release"
 , "main": "./build/Release/robotskirt"
 , "scripts": { "publish": "node-waf configure build" }

--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -158,10 +158,13 @@ static Handle<Value> ToHtmlSync(const Arguments &args) {
   return scope.Close(md);
 }
  
-extern "C" void init (Handle<Object> target) {
-  HandleScope scope;
+extern "C" {
+  void init (Handle<Object> target) {
+    HandleScope scope;
 
-  target->Set(String::New("version"), String::New("0.2.2"));
-  NODE_SET_METHOD(target, "toHtml", ToHtmlAsync);
-  NODE_SET_METHOD(target, "toHtmlSync", ToHtmlSync);
+    target->Set(String::New("version"), String::New("0.2.2"));
+    NODE_SET_METHOD(target, "toHtml", ToHtmlAsync);
+    NODE_SET_METHOD(target, "toHtmlSync", ToHtmlSync);
+  }
+  NODE_MODULE(robotskirt, init)
 }

--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -162,9 +162,18 @@ extern "C" {
   void init (Handle<Object> target) {
     HandleScope scope;
 
-    target->Set(String::New("version"), String::New("0.2.2"));
+    target->Set(String::NewSymbol("version"), String::New("0.2.2"));
     NODE_SET_METHOD(target, "toHtml", ToHtmlAsync);
     NODE_SET_METHOD(target, "toHtmlSync", ToHtmlSync);
+    
+    //Set extensions
+    target->Set(String::NewSymbol("EXT_AUTOLINK"), Integer::New(MKDEXT_AUTOLINK));
+    target->Set(String::NewSymbol("EXT_FENCED_CODE"), Integer::New(MKDEXT_FENCED_CODE));
+    target->Set(String::NewSymbol("EXT_LAX_HTML_BLOCKS"), Integer::New(MKDEXT_LAX_HTML_BLOCKS));
+    target->Set(String::NewSymbol("EXT_NO_INTRA_EMPHASIS"), Integer::New(MKDEXT_NO_INTRA_EMPHASIS));
+    target->Set(String::NewSymbol("EXT_SPACE_HEADERS"), Integer::New(MKDEXT_SPACE_HEADERS));
+    target->Set(String::NewSymbol("EXT_STRIKETHROUGH"), Integer::New(MKDEXT_STRIKETHROUGH));
+    target->Set(String::NewSymbol("EXT_TABLES"), Integer::New(MKDEXT_TABLES));
   }
   NODE_MODULE(robotskirt, init)
 }


### PR DESCRIPTION
Great work with Robotskirt, let's make it more complete!
And it's now even faster (it allows Renderer to be used multiple times)!
See [the benchmark](https://github.com/jmendeth/robotskirt/blob/d6689935813d800b9c0cae54d573ecbdd8509271/README.mkd).
## New features
1. A class named `Renderer` has been created which wraps a `mkd_renderer`.
2. Another class `HtmlRenderer` (which inherits from the above) wraps the standard (X)HTML renderer bundled with Sundown.
3. The render functions (`toHtml` and `toHtmlSync`) now require a `Renderer` as first argument.  
   Thus, they've been renamed to `markdown` and `markdownSync`.
4. The functions now check the _types_ of their arguments (prevents crashes when passing `null`).  
5. The extension flags have been exposed as module properties:  
   `EXT_AUTOLINK`
   `EXT_FENCED_CODE`
   `EXT_LAX_HTML_BLOCKS`
   `EXT_TABLES`  
   `EXT_NO_INTRA_EMPHASIS`
   `EXT_SPACE_HEADERS`
   `EXT_STRIKETHROUGH`
6. The renderer functions now accept extension flags as the (optional) last argument.
## Other optimizations
- Use the `NODE_MODULE` macro.
- The output buffer is directly converted to a JS `Buffer` instead of copying its contents.
- Use RAII to make sure the `mkd_renderer` is always deleted, no matter what happens.
- Those improvements break compatibility, so bumping version to `1.0.0`.
- Keep documentation, examples & benchmarks up-to-date.
- Extend / document new features on README
- Update benchmark to call the right function.
