### PR TITLE
Add node-gyp support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,8 @@
 {
+  'target_defaults': {
+    'cflags!': [ '-fno-exceptions' ],
+    'cflags_cc!': [ '-fno-exceptions' ]
+  },
   'targets': [
     {
       'target_name': 'sundown',

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,35 @@
+{
+  'targets': [
+    {
+      'target_name': 'sundown',
+      'type': 'static_library',
+      'include_dirs': ['src/'],
+      'sources': [
+        'src/autolink.c',
+        'src/buffer.c',
+        'src/houdini_href_e.c',
+        'src/houdini_html_e.c',
+        'src/houdini_html_u.c',
+        'src/houdini_js_e.c',
+        'src/houdini_js_u.c',
+        'src/houdini_uri_e.c',
+        'src/houdini_uri_u.c',
+        'src/houdini_xml_e.c',
+        'src/html.c',
+        'src/html_smartypants.c',
+        'src/markdown.c',
+        'src/stack.c',
+      ]
+    },
+    {
+      'target_name': 'robotskirt',
+      'sources': ['src/robotskirt.cc'],
+      'cflags': ['-Wall'],
+      'defines': [
+        '_FILE_OFFSET_BITS=64',
+        '_LARGEFILE_SOURCE'
+      ],
+      'dependencies': ['sundown']
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a `bindings.gyp` allowing robotskirt to be built with node-gyp. I left `wscript` in tact so node-waf can still be used if necessary.

I've tested this on both Linux and Windows*, but I don't have access to an OS X image so there may be issues there, especially around the CFLAGS.

\* Windows support requires one additional tweak which will be submitted as a separate PR.
