### PR TITLE
Fix compilation on Windows (MSVC)

### DIFF
--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -345,7 +345,7 @@ WRAPPERS(BUF4)
         HandleScope scope;                                                     \
                                                                                \
         /*Convert arguments*/                                                  \
-        Handle<Value> *args = NULL;                                            \
+        Handle<Value> args[1];                                                 \
                                                                                \
         /*Call it!*/                                                           \
         TryCatch trycatch;                                                     \

--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -345,7 +345,7 @@ WRAPPERS(BUF4)
         HandleScope scope;                                                     \
                                                                                \
         /*Convert arguments*/                                                  \
-        Handle<Value> *args;                                                   \
+        Handle<Value> *args = NULL;                                            \
                                                                                \
         /*Call it!*/                                                           \
         TryCatch trycatch;                                                     \

--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -345,7 +345,7 @@ WRAPPERS(BUF4)
         HandleScope scope;                                                     \
                                                                                \
         /*Convert arguments*/                                                  \
-        Handle<Value> args[1];                                                 \
+        Handle<Value> args [1];                                                \
                                                                                \
         /*Call it!*/                                                           \
         TryCatch trycatch;                                                     \

--- a/src/robotskirt.cc
+++ b/src/robotskirt.cc
@@ -345,7 +345,7 @@ WRAPPERS(BUF4)
         HandleScope scope;                                                     \
                                                                                \
         /*Convert arguments*/                                                  \
-        Handle<Value> args [0];                                                \
+        Handle<Value> *args;                                                   \
                                                                                \
         /*Call it!*/                                                           \
         TryCatch trycatch;                                                     \


### PR DESCRIPTION
This replaces a GCC-only extension (zero-length array) with a portable equivalent. C99 would have allowed something like:

``` c
Handle<Value> args[];
```

But MSVC doesn't implement that part of C99, so the extra element (and stack usage) is needed.
